### PR TITLE
Auth ::check() issue after ::create_login_hash()

### DIFF
--- a/classes/auth/login/simpleauth.php
+++ b/classes/auth/login/simpleauth.php
@@ -321,6 +321,8 @@ class Auth_Login_SimpleAuth extends \Auth_Login_Driver {
 			->set(array('last_login' => $last_login, 'login_hash' => $login_hash))
 			->where('username', '=', $this->user['username'])->execute();
 
+		$this->user['login_hash'] = $login_hash;
+
 		return $login_hash;
 	}
 


### PR DESCRIPTION
Fixed an issue where the new login hash was not saved into the current user array and the auth check would fail.

Example:

<code>
$auth = Auth::instance();
var_dump($auth->check());
$auth->logout();
var_dump($auth->check());
$bool = $auth->login('myuser', 'mypassword');
var_dump($auth->check());
// This is where it would break and return false some of the time due to the login hash
</code>

After storing it in the user array it was stable.
