### PR TITLE
Added support for string formatted access.

### DIFF
--- a/classes/auth/acl/simpleacl.php
+++ b/classes/auth/acl/simpleacl.php
@@ -25,6 +25,12 @@ class Auth_Acl_SimpleAcl extends \Auth_Acl_Driver {
 	public function has_access($condition, Array $entity)
 	{
 		$group = \Auth::group($entity[0]);
+		
+		if(is_string($condition) and stripos($condition, '.') !== false)
+		{
+			$condition = explode('.', $condition);
+		}
+		
 		if ( ! is_array($condition) || empty($group) || ! is_callable(array($group, 'get_roles')))
 		{
 			return false;


### PR DESCRIPTION
So
$auth->has_access(array('website','read'))
can be written as
$auth->has_access('website.read')
