### PR TITLE
Added support for string formatted access.

### DIFF
--- a/classes/auth/acl/driver.php
+++ b/classes/auth/acl/driver.php
@@ -49,6 +49,38 @@ abstract class Auth_Acl_Driver extends \Auth_Driver {
 
 		return $driver;
 	}
+	
+	/**
+	 * Parses a conditions string into it's array equivalent
+	 *
+	 * @rights	mixed	conditions array or string
+	 * @return	array	conditions array formatted as array(area, rights)
+	 *
+	 */
+	public static function _parse_conditions($rights)
+	{
+		if(is_array($rights))
+		{
+			return $rights;
+		}
+		
+		if( ! is_string($rights) or stripos($rights, '.') === false)
+		{
+			var_dump($rights);
+			var_dump(is_array($rights));
+			die();
+			throw new \InvalidArgumentException('Given rights where not formatted proppery. Formatting should be like area.right or area.[right, other_right]. Received: '.$rights);
+		}
+		
+		list($area, $rights) = explode('.', $rights);
+		
+		if(substr($rights, 0 , 1) === '[')
+		{
+			$rights = explode(',', str_replace(array('[', ']', ' '), '', $rights));
+		}
+		
+		return array($area, $rights);
+	}
 
 	// ------------------------------------------------------------------------
 

--- a/classes/auth/acl/simpleacl.php
+++ b/classes/auth/acl/simpleacl.php
@@ -25,6 +25,12 @@ class Auth_Acl_SimpleAcl extends \Auth_Acl_Driver {
 	public function has_access($condition, Array $entity)
 	{
 		$group = \Auth::group($entity[0]);
+		
+		if(is_string($condition) and stripos($condition, '.') !== false)
+		{
+			$condition = explode('.', $condition);
+		}
+		
 		if ( ! is_array($condition) || empty($group) || ! is_callable(array($group, 'get_roles')))
 		{
 			return false;

--- a/classes/auth/acl/simpleacl.php
+++ b/classes/auth/acl/simpleacl.php
@@ -26,10 +26,7 @@ class Auth_Acl_SimpleAcl extends \Auth_Acl_Driver {
 	{
 		$group = \Auth::group($entity[0]);
 		
-		if(is_string($condition) and stripos($condition, '.') !== false)
-		{
-			$condition = explode('.', $condition);
-		}
+		$condition = static::_parse_conditions($condition);
 		
 		if ( ! is_array($condition) || empty($group) || ! is_callable(array($group, 'get_roles')))
 		{


### PR DESCRIPTION
And included support for multiple rights on.

$auth->has_access('admin.[read, edit, delete]');

or

$auth->has_access('admin.read');

or normally

$auth->has_access(array('admin', array('read', 'edit', 'delete')));

or 

$auth->has_access(array('admin', 'read'));

How flexible.
