### PR TITLE
Auth BadFunctionCallException now has included class and function name so we know what's going on.

### DIFF
--- a/classes/auth.php
+++ b/classes/auth.php
@@ -337,7 +337,7 @@ class Auth {
 			return call_user_func_array(array(static::$_instance, $method), $args);
 		}
 
-		throw new \BadMethodCallException('Invalid method.');
+		throw new \BadMethodCallException('Invalid method: '.get_called_class().'::'.$method);
 	}
 
 	/**


### PR DESCRIPTION
Using get_called_class for when the class is extended.
