### PR TITLE
Trim password

### DIFF
--- a/classes/auth/login/simpleauth.php
+++ b/classes/auth/login/simpleauth.php
@@ -184,6 +184,7 @@ class Auth_Login_SimpleAuth extends \Auth_Login_Driver {
 	 */
 	public function create_user($username, $password, $email, $group = 1, Array $profile_fields = array())
 	{
+		$password = trim($password);
 		$email = filter_var(trim($email), FILTER_VALIDATE_EMAIL);
 
 		if (empty($username) or empty($password) or empty($email))
@@ -251,15 +252,17 @@ class Auth_Login_SimpleAuth extends \Auth_Login_Driver {
 		}
 		if (array_key_exists('password', $values))
 		{
-			if ($current_values->get('password') != $this->hash_password(@$values['old_password']))
+			if ($current_values->get('password') != $this->hash_password(trim(@$values['old_password'])))
 			{
 				throw new \SimpleUserWrongPassword('Old password is invalid');
 			}
 
-			if ( ! empty($values['password']))
+			$password = trim($values['password']);
+			if ( ! $password)
 			{
-				$update['password'] = $this->hash_password($values['password']);
+				throw new \SimpleUserUpdateException('Password can\'t be empty.')
 			}
+			$update['password'] = $this->hash_password($values['password']);
 			unset($values['password']);
 		}
 		if (array_key_exists('old_password', $values))


### PR DESCRIPTION
This fixes:
  Giving a user a password that is just spaces or ends with spaces, will make it impossible to login since the login method trims the password.
  The old_password check in `update_user` will fail to match.
