### PR TITLE
The method has been renamed in the login driver

### DIFF
--- a/classes/auth/group/driver.php
+++ b/classes/auth/group/driver.php
@@ -97,7 +97,7 @@ abstract class Auth_Group_Driver extends \Auth_Driver
 		foreach (\Auth::verified() as $v)
 		{
 			// ... and check all those their groups
-			$gs = $v->get_user_groups();
+			$gs = $v->get_groups();
 			foreach ($gs as $g_id)
 			{
 				// ... and try to validate if its group is this one


### PR DESCRIPTION
The method to aquire the groups for a user has been renamed by commit c2317aad3b54393092932302ef7180227869567a but the change wasn't propagated here.
