### PR TITLE
return get_user_id() as an associative array

### DIFF
--- a/classes/auth/login/simpleauth.php
+++ b/classes/auth/login/simpleauth.php
@@ -445,7 +445,10 @@ class Auth_Login_SimpleAuth extends \Auth_Login_Driver
 			return false;
 		}
 
-		return array($this->id, (int) $this->user['id']);
+		return array(
+			'driver_id' => $this->id,
+			'user_id' = >(int) $this->user['id']
+			);
 	}
 
 	/**


### PR DESCRIPTION
To make it easier to read and debug, return get_user_id as an associative array.

Array(driver_id,user_id)

Keys are 'driver_id' & 'user_id'
