### PR TITLE
Added registration on login to SimpleAuth for #43

### DIFF
--- a/classes/auth/login/simpleauth.php
+++ b/classes/auth/login/simpleauth.php
@@ -136,6 +136,9 @@ class Auth_Login_SimpleAuth extends \Auth_Login_Driver
 			return false;
 		}
 
+		// register so Auth::logout() can find us
+		Auth::_register_verified($this);
+
 		\Session::set('username', $this->user['username']);
 		\Session::set('login_hash', $this->create_login_hash());
 		\Session::instance()->rotate();


### PR DESCRIPTION
SimpleAuth now registers itself with Auth as a validated driver during login().
If Auth::logout() was called without previously calling Auth::check(), SimpleAuth would retain a valid login.
