### PR TITLE
Changed table name in the create_index function to use config

### DIFF
--- a/examples/001_auth_create_simpleauth_table.php
+++ b/examples/001_auth_create_simpleauth_table.php
@@ -24,7 +24,7 @@ class Auth_Create_Simpleauth_Table
 		), array('id'));
 
 		// add a unique index on username and email
-		\DBUtil::create_index(\Config::get('simpleauth.table_name', 'users'), array('username', 'email'), 'username', 'UNIQUE');
+		\DBUtil::create_index($table, array('username', 'email'), 'username', 'UNIQUE');
 	}
 
 	function down()

--- a/examples/001_auth_create_simpleauth_table.php
+++ b/examples/001_auth_create_simpleauth_table.php
@@ -24,7 +24,7 @@ class Auth_Create_Simpleauth_Table
 		), array('id'));
 
 		// add a unique index on username and email
-		\DBUtil::create_index('users', array('username', 'email'), 'username', 'UNIQUE');
+		\DBUtil::create_index(\Config::get('simpleauth.table_name', 'users'), array('username', 'email'), 'username', 'UNIQUE');
 	}
 
 	function down()


### PR DESCRIPTION
The table name in the create_index was 'users', changed it to \Config::get('simpleauth.table_name', 'users')
