### PR TITLE
Correct group driver has_access when no group given

### DIFF
--- a/classes/auth/group/driver.php
+++ b/classes/auth/group/driver.php
@@ -90,7 +90,7 @@ abstract class Auth_Group_Driver extends \Auth_Driver
 			foreach ($gs as $g_id)
 			{
 				// ... and try to validate if its group is this one
-				if ($this instanceof $g_id[0])
+				if ($this->id = $g_id[0])
 				{
 					if ($this->has_access($condition, $driver, $g_id))
 					{


### PR DESCRIPTION
When no group given it checks for all logged in drivers and their group drivers by get_groups method. Since this method returns only the id of the group driver, and not an instance, I replaced it with checking the id of the group.
