### PR TITLE
Bugfix: default group fieldname should be group_id

### DIFF
--- a/classes/auth/login/simpleauth.php
+++ b/classes/auth/login/simpleauth.php
@@ -254,7 +254,7 @@ class Auth_Login_Simpleauth extends \Auth_Login_Driver
 			'username'        => (string) $username,
 			'password'        => $this->hash_password((string) $password),
 			'email'           => $email,
-			'group'           => (int) $group,
+			'group_id'        => (int) $group,
 			'profile_fields'  => serialize($profile_fields),
 			'last_login'      => 0,
 			'login_hash'      => '',


### PR DESCRIPTION
Auth::create_user in oil console fails with: 
`Parse Error - SQLSTATE[42S22]: Column not found: 1054 Unknown column 'group' in 'field list' with query:`
