### PR TITLE
Bugfix key_to relationship for "group has many users"

### DIFF
--- a/classes/model/auth/group.php
+++ b/classes/model/auth/group.php
@@ -82,7 +82,7 @@ class Auth_Group extends \Orm\Model
 		'users' => array(
 			'model_to' => 'Model\\Auth_User',
 			'key_from' => 'id',
-			'key_to'   => 'group',
+			'key_to'   => 'group_id',
 		),
 		'grouppermission' => array(
 			'model_to' => 'Model\\Auth_Grouppermission',


### PR DESCRIPTION
It's "group_id', not "group"
