### PR TITLE
Update ormauth.php

### DIFF
--- a/classes/auth/login/ormauth.php
+++ b/classes/auth/login/ormauth.php
@@ -253,7 +253,7 @@ class Auth_Login_Ormauth extends \Auth_Login_Driver
 		}
 
 		// do we have a logged-in user?
-		if ($currentuser = \Auth::get_user_id())
+		if ($currentuser = \Auth::instance()->get_user_id())
 		{
 			$currentuser = $currentuser[1];
 		}


### PR DESCRIPTION
Fixes invalid method call during user_creation

Hit an issue when running migrations on a new application.  Auth::get_user_id() does not exist, so have replaced the call with Auth::instance()->get_user_id()
