### PR TITLE
unregister_driver_type possible bug in_array not properly initialized

### DIFF
--- a/classes/auth.php
+++ b/classes/auth.php
@@ -306,7 +306,7 @@ class Auth
 	 */
 	public static function unregister_driver_type($type)
 	{
-		if (in_array('login', 'group', 'acl'))
+		if (in_array($type,array('login', 'group', 'acl')))
 		{
 			\Error::notice('Cannot remove driver type, included drivers login, group and acl cannot be removed.');
 			return false;


### PR DESCRIPTION
i might be wrong, but it appears that the in_array is missing the "type" argument and that the options defined are not an "array" this also affects version 1.7
