### PR TITLE
Allow Replication to be Used

### DIFF
--- a/classes/model/auth/group.php
+++ b/classes/model/auth/group.php
@@ -18,6 +18,11 @@ class Auth_Group extends \Orm\Model
 	 * @var  string  connection to use
 	 */
 	protected static $_connection = null;
+	
+	/**
+	 * @var  string  write connection to use
+	 */
+    protected static $_write_connection = null;
 
 	/**
 	 * @var  string  table name to overwrite assumption
@@ -124,6 +129,9 @@ class Auth_Group extends \Orm\Model
 
 		// set the connection this model should use
 		static::$_connection = \Config::get('ormauth.db_connection');
+		
+		// set the write connection this model should use
+		static::$_connection = \Config::get('ormauth.db_write_connection');
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_groups';

--- a/classes/model/auth/grouppermission.php
+++ b/classes/model/auth/grouppermission.php
@@ -18,6 +18,11 @@ class Auth_Grouppermission extends \Orm\Model
 	 * @var  string  connection to use
 	 */
 	protected static $_connection = null;
+	
+	/**
+	 * @var  string  write connection to use
+	 */
+    protected static $_write_connection = null;
 
 	/**
 	 * @var  string  table name to overwrite assumption
@@ -79,6 +84,9 @@ class Auth_Grouppermission extends \Orm\Model
 
 		// set the connection this model should use
 		static::$_connection = \Config::get('ormauth.db_connection');
+		
+		// set the write connection this model should use
+		static::$_connection = \Config::get('ormauth.db_write_connection');
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_group_permissions';

--- a/classes/model/auth/metadata.php
+++ b/classes/model/auth/metadata.php
@@ -18,6 +18,11 @@ class Auth_Metadata extends \Orm\Model
 	 * @var  string  connection to use
 	 */
 	protected static $_connection = null;
+	
+	/**
+	 * @var  string  write connection to use
+	 */
+    protected static $_write_connection = null;
 
 	/**
 	 * @var  string  table name to overwrite assumption
@@ -93,6 +98,9 @@ class Auth_Metadata extends \Orm\Model
 
 		// set the connection this model should use
 		static::$_connection = \Config::get('ormauth.db_connection');
+		
+		// set the write connection this model should use
+		static::$_connection = \Config::get('ormauth.db_write_connection');
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_metadata';

--- a/classes/model/auth/permission.php
+++ b/classes/model/auth/permission.php
@@ -18,6 +18,11 @@ class Auth_Permission extends \Orm\Model
 	 * @var  string  connection to use
 	 */
 	protected static $_connection = null;
+	
+	/**
+	 * @var  string  write connection to use
+	 */
+    protected static $_write_connection = null;
 
 	/**
 	 * @var  string  table name to overwrite assumption
@@ -130,6 +135,9 @@ class Auth_Permission extends \Orm\Model
 
 		// set the connection this model should use
 		static::$_connection = \Config::get('ormauth.db_connection');
+		
+		// set the write connection this model should use
+		static::$_connection = \Config::get('ormauth.db_write_connection');
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_permissions';

--- a/classes/model/auth/role.php
+++ b/classes/model/auth/role.php
@@ -18,6 +18,11 @@ class Auth_Role extends \Orm\Model
 	 * @var  string  connection to use
 	 */
 	protected static $_connection = null;
+	
+	/**
+	 * @var  string  write connection to use
+	 */
+    protected static $_write_connection = null;
 
 	/**
 	 * @var  string  table name to overwrite assumption
@@ -137,6 +142,9 @@ class Auth_Role extends \Orm\Model
 
 		// set the connection this model should use
 		static::$_connection = \Config::get('ormauth.db_connection');
+		
+		// set the write connection this model should use
+		static::$_connection = \Config::get('ormauth.db_write_connection');
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_roles';

--- a/classes/model/auth/rolepermission.php
+++ b/classes/model/auth/rolepermission.php
@@ -18,6 +18,11 @@ class Auth_Rolepermission extends \Orm\Model
 	 * @var  string  connection to use
 	 */
 	protected static $_connection = null;
+	
+	/**
+	 * @var  string  write connection to use
+	 */
+    protected static $_write_connection = null;
 
 	/**
 	 * @var  string  table name to overwrite assumption
@@ -79,6 +84,9 @@ class Auth_Rolepermission extends \Orm\Model
 
 		// set the connection this model should use
 		static::$_connection = \Config::get('ormauth.db_connection');
+		
+		// set the write connection this model should use
+		static::$_connection = \Config::get('ormauth.db_write_connection');
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_role_permissions';

--- a/classes/model/auth/user.php
+++ b/classes/model/auth/user.php
@@ -18,6 +18,11 @@ class Auth_User extends \Orm\Model
 	 * @var  string  connection to use
 	 */
 	protected static $_connection = null;
+	
+	/**
+	 * @var  string  write connection to use
+	 */
+    protected static $_write_connection = null;
 
 	/**
 	 * @var  string  table name to overwrite assumption
@@ -210,6 +215,9 @@ class Auth_User extends \Orm\Model
 
 			// set the connection this model should use
 			static::$_connection = \Config::get('simpleauth.db_connection');
+		
+			// set the write connection this model should use
+			static::$_connection = \Config::get('simpleauth.db_write_connection');
 
 			// set the models table name
 			static::$_table_name = \Config::get('simpleauth.table_name', 'users');
@@ -226,6 +234,9 @@ class Auth_User extends \Orm\Model
 
 			// set the connection this model should use
 			static::$_connection = \Config::get('ormauth.db_connection');
+		
+			// set the write connection this model should use
+			static::$_connection = \Config::get('ormauth.db_write_connection');
 
 			// set the models table name
 			static::$_table_name = \Config::get('ormauth.table_name', 'users');

--- a/classes/model/auth/userpermission.php
+++ b/classes/model/auth/userpermission.php
@@ -18,6 +18,11 @@ class Auth_Userpermission extends \Orm\Model
 	 * @var  string  connection to use
 	 */
 	protected static $_connection = null;
+	
+	/**
+	 * @var  string  write connection to use
+	 */
+    protected static $_write_connection = null;
 
 	/**
 	 * @var  string  table name to overwrite assumption
@@ -79,6 +84,9 @@ class Auth_Userpermission extends \Orm\Model
 
 		// set the connection this model should use
 		static::$_connection = \Config::get('ormauth.db_connection');
+		
+		// set the write connection this model should use
+		static::$_connection = \Config::get('ormauth.db_write_connection');
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_user_permissions';

--- a/config/ormauth.php
+++ b/config/ormauth.php
@@ -24,7 +24,12 @@ return array(
 	/**
 	 * DB connection, leave null to use default
 	 */
-	'db_connection' => null,
+	'db_connection' 	=> null,
+	
+	/**
+	 * DB write connection, leave null to use default
+	 */
+	'db_write_connection' 	=> null,
 
 	/**
 	 * DB table name for the user table

--- a/config/simpleauth.php
+++ b/config/simpleauth.php
@@ -27,6 +27,11 @@ return array(
 	 * DB connection, leave null to use default
 	 */
 	'db_connection' => null,
+	
+	/**
+	 * DB write connection, leave null to use default
+	 */
+	'db_write_connection' 	=> null,
 
 	/**
 	 * DB table name for the user table


### PR DESCRIPTION
Auth Library did not respect the ORM Replication setup defined here:
http://fuelphp.com/docs/packages/orm/creating_models.html#/write_connection

This pull adjusts that
