### PR TITLE
Fixed wrong 'write_connection' variable name for models.

### DIFF
--- a/classes/model/auth/group.php
+++ b/classes/model/auth/group.php
@@ -131,7 +131,7 @@ class Auth_Group extends \Orm\Model
 		static::$_connection = \Config::get('ormauth.db_connection');
 		
 		// set the write connection this model should use
-		static::$_connection = \Config::get('ormauth.db_write_connection');
+		static::$_write_connection = \Config::get('ormauth.db_write_connection');
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_groups';

--- a/classes/model/auth/group.php
+++ b/classes/model/auth/group.php
@@ -131,7 +131,7 @@ class Auth_Group extends \Orm\Model
 		static::$_connection = \Config::get('ormauth.db_connection');
 		
 		// set the write connection this model should use
-		static::$_write_connection = \Config::get('ormauth.db_write_connection');
+		static::$_write_connection = \Config::get('ormauth.db_write_connection', static::$_connection);
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_groups';

--- a/classes/model/auth/grouppermission.php
+++ b/classes/model/auth/grouppermission.php
@@ -86,7 +86,7 @@ class Auth_Grouppermission extends \Orm\Model
 		static::$_connection = \Config::get('ormauth.db_connection');
 		
 		// set the write connection this model should use
-		static::$_connection = \Config::get('ormauth.db_write_connection');
+		static::$_write_connection = \Config::get('ormauth.db_write_connection');
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_group_permissions';

--- a/classes/model/auth/grouppermission.php
+++ b/classes/model/auth/grouppermission.php
@@ -86,7 +86,7 @@ class Auth_Grouppermission extends \Orm\Model
 		static::$_connection = \Config::get('ormauth.db_connection');
 		
 		// set the write connection this model should use
-		static::$_write_connection = \Config::get('ormauth.db_write_connection');
+		static::$_write_connection = \Config::get('ormauth.db_write_connection', static::$_connection);
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_group_permissions';

--- a/classes/model/auth/metadata.php
+++ b/classes/model/auth/metadata.php
@@ -100,7 +100,7 @@ class Auth_Metadata extends \Orm\Model
 		static::$_connection = \Config::get('ormauth.db_connection');
 		
 		// set the write connection this model should use
-		static::$_connection = \Config::get('ormauth.db_write_connection');
+		static::$_write_connection = \Config::get('ormauth.db_write_connection');
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_metadata';

--- a/classes/model/auth/metadata.php
+++ b/classes/model/auth/metadata.php
@@ -100,7 +100,7 @@ class Auth_Metadata extends \Orm\Model
 		static::$_connection = \Config::get('ormauth.db_connection');
 		
 		// set the write connection this model should use
-		static::$_write_connection = \Config::get('ormauth.db_write_connection');
+		static::$_write_connection = \Config::get('ormauth.db_write_connection', static::$_connection);
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_metadata';

--- a/classes/model/auth/permission.php
+++ b/classes/model/auth/permission.php
@@ -137,7 +137,7 @@ class Auth_Permission extends \Orm\Model
 		static::$_connection = \Config::get('ormauth.db_connection');
 		
 		// set the write connection this model should use
-		static::$_write_connection = \Config::get('ormauth.db_write_connection');
+		static::$_write_connection = \Config::get('ormauth.db_write_connection', static::$_connection);
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_permissions';

--- a/classes/model/auth/permission.php
+++ b/classes/model/auth/permission.php
@@ -137,7 +137,7 @@ class Auth_Permission extends \Orm\Model
 		static::$_connection = \Config::get('ormauth.db_connection');
 		
 		// set the write connection this model should use
-		static::$_connection = \Config::get('ormauth.db_write_connection');
+		static::$_write_connection = \Config::get('ormauth.db_write_connection');
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_permissions';

--- a/classes/model/auth/role.php
+++ b/classes/model/auth/role.php
@@ -144,7 +144,7 @@ class Auth_Role extends \Orm\Model
 		static::$_connection = \Config::get('ormauth.db_connection');
 		
 		// set the write connection this model should use
-		static::$_connection = \Config::get('ormauth.db_write_connection');
+		static::$_write_connection = \Config::get('ormauth.db_write_connection');
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_roles';

--- a/classes/model/auth/role.php
+++ b/classes/model/auth/role.php
@@ -144,7 +144,7 @@ class Auth_Role extends \Orm\Model
 		static::$_connection = \Config::get('ormauth.db_connection');
 		
 		// set the write connection this model should use
-		static::$_write_connection = \Config::get('ormauth.db_write_connection');
+		static::$_write_connection = \Config::get('ormauth.db_write_connection', static::$_connection);
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_roles';

--- a/classes/model/auth/rolepermission.php
+++ b/classes/model/auth/rolepermission.php
@@ -86,7 +86,7 @@ class Auth_Rolepermission extends \Orm\Model
 		static::$_connection = \Config::get('ormauth.db_connection');
 		
 		// set the write connection this model should use
-		static::$_connection = \Config::get('ormauth.db_write_connection');
+		static::$_write_connection = \Config::get('ormauth.db_write_connection');
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_role_permissions';

--- a/classes/model/auth/rolepermission.php
+++ b/classes/model/auth/rolepermission.php
@@ -86,7 +86,7 @@ class Auth_Rolepermission extends \Orm\Model
 		static::$_connection = \Config::get('ormauth.db_connection');
 		
 		// set the write connection this model should use
-		static::$_write_connection = \Config::get('ormauth.db_write_connection');
+		static::$_write_connection = \Config::get('ormauth.db_write_connection', static::$_connection);
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_role_permissions';

--- a/classes/model/auth/user.php
+++ b/classes/model/auth/user.php
@@ -217,7 +217,7 @@ class Auth_User extends \Orm\Model
 			static::$_connection = \Config::get('simpleauth.db_connection');
 		
 			// set the write connection this model should use
-			static::$_write_connection = \Config::get('simpleauth.db_write_connection');
+			static::$_write_connection = \Config::get('simpleauth.db_write_connection', static::$_connection);
 
 			// set the models table name
 			static::$_table_name = \Config::get('simpleauth.table_name', 'users');
@@ -236,7 +236,7 @@ class Auth_User extends \Orm\Model
 			static::$_connection = \Config::get('ormauth.db_connection');
 		
 			// set the write connection this model should use
-			static::$_write_connection = \Config::get('ormauth.db_write_connection');
+			static::$_write_connection = \Config::get('ormauth.db_write_connection', static::$_connection);
 
 			// set the models table name
 			static::$_table_name = \Config::get('ormauth.table_name', 'users');

--- a/classes/model/auth/user.php
+++ b/classes/model/auth/user.php
@@ -217,7 +217,7 @@ class Auth_User extends \Orm\Model
 			static::$_connection = \Config::get('simpleauth.db_connection');
 		
 			// set the write connection this model should use
-			static::$_connection = \Config::get('simpleauth.db_write_connection');
+			static::$_write_connection = \Config::get('simpleauth.db_write_connection');
 
 			// set the models table name
 			static::$_table_name = \Config::get('simpleauth.table_name', 'users');
@@ -236,7 +236,7 @@ class Auth_User extends \Orm\Model
 			static::$_connection = \Config::get('ormauth.db_connection');
 		
 			// set the write connection this model should use
-			static::$_connection = \Config::get('ormauth.db_write_connection');
+			static::$_write_connection = \Config::get('ormauth.db_write_connection');
 
 			// set the models table name
 			static::$_table_name = \Config::get('ormauth.table_name', 'users');

--- a/classes/model/auth/userpermission.php
+++ b/classes/model/auth/userpermission.php
@@ -86,7 +86,7 @@ class Auth_Userpermission extends \Orm\Model
 		static::$_connection = \Config::get('ormauth.db_connection');
 		
 		// set the write connection this model should use
-		static::$_connection = \Config::get('ormauth.db_write_connection');
+		static::$_write_connection = \Config::get('ormauth.db_write_connection');
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_user_permissions';

--- a/classes/model/auth/userpermission.php
+++ b/classes/model/auth/userpermission.php
@@ -86,7 +86,7 @@ class Auth_Userpermission extends \Orm\Model
 		static::$_connection = \Config::get('ormauth.db_connection');
 		
 		// set the write connection this model should use
-		static::$_write_connection = \Config::get('ormauth.db_write_connection');
+		static::$_write_connection = \Config::get('ormauth.db_write_connection', static::$_connection);
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_user_permissions';

--- a/config/ormauth.php
+++ b/config/ormauth.php
@@ -27,7 +27,7 @@ return array(
 	'db_connection' 	=> null,
 	
 	/**
-	 * DB write connection, leave null to use default
+	 * DB write connection, leave null to use same value as db_connection
 	 */
 	'db_write_connection' 	=> null,
 

--- a/config/simpleauth.php
+++ b/config/simpleauth.php
@@ -29,7 +29,7 @@ return array(
 	'db_connection' => null,
 	
 	/**
-	 * DB write connection, leave null to use default
+	 * DB write connection, leave null to use same value as db_connection
 	 */
 	'db_write_connection' 	=> null,
 


### PR DESCRIPTION
After upgrade to 1.7.2 I did not realise you had to set the `db_write_connection` variable. And so realised that the normal `$_connection` was getting overridden to `null` as I use a different DB for Auth stuff.

So I believe there is a miss type in the variable names, but correct me if I'm wrong.

**Update:** Also some how believe that if `ormauth.db_write_connection` is null, then it should use the ormauth.db_connecton' setting as default (instead of null), as we presume then its not different front he read connection. Right now it would pull from "default" which would be a different connection. (2nd commit)
