### PR TITLE
Fix if write_connection config is null, default to connection.

### DIFF
--- a/classes/model/auth/group.php
+++ b/classes/model/auth/group.php
@@ -131,7 +131,7 @@ class Auth_Group extends \Orm\Model
 		static::$_connection = \Config::get('ormauth.db_connection');
 		
 		// set the write connection this model should use
-		static::$_write_connection = \Config::get('ormauth.db_write_connection', static::$_connection);
+		static::$_write_connection = \Config::get('ormauth.db_write_connection') ?: static::$_connection;
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_groups';

--- a/classes/model/auth/grouppermission.php
+++ b/classes/model/auth/grouppermission.php
@@ -86,7 +86,7 @@ class Auth_Grouppermission extends \Orm\Model
 		static::$_connection = \Config::get('ormauth.db_connection');
 		
 		// set the write connection this model should use
-		static::$_write_connection = \Config::get('ormauth.db_write_connection', static::$_connection);
+		static::$_write_connection = \Config::get('ormauth.db_write_connection') ?: static::$_connection;
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_group_permissions';

--- a/classes/model/auth/metadata.php
+++ b/classes/model/auth/metadata.php
@@ -100,7 +100,7 @@ class Auth_Metadata extends \Orm\Model
 		static::$_connection = \Config::get('ormauth.db_connection');
 		
 		// set the write connection this model should use
-		static::$_write_connection = \Config::get('ormauth.db_write_connection', static::$_connection);
+		static::$_write_connection = \Config::get('ormauth.db_write_connection') ?: static::$_connection;
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_metadata';

--- a/classes/model/auth/permission.php
+++ b/classes/model/auth/permission.php
@@ -137,7 +137,7 @@ class Auth_Permission extends \Orm\Model
 		static::$_connection = \Config::get('ormauth.db_connection');
 		
 		// set the write connection this model should use
-		static::$_write_connection = \Config::get('ormauth.db_write_connection', static::$_connection);
+		static::$_write_connection = \Config::get('ormauth.db_write_connection') ?: static::$_connection;
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_permissions';

--- a/classes/model/auth/role.php
+++ b/classes/model/auth/role.php
@@ -144,7 +144,7 @@ class Auth_Role extends \Orm\Model
 		static::$_connection = \Config::get('ormauth.db_connection');
 		
 		// set the write connection this model should use
-		static::$_write_connection = \Config::get('ormauth.db_write_connection', static::$_connection);
+		static::$_write_connection = \Config::get('ormauth.db_write_connection') ?: static::$_connection;
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_roles';

--- a/classes/model/auth/rolepermission.php
+++ b/classes/model/auth/rolepermission.php
@@ -86,7 +86,7 @@ class Auth_Rolepermission extends \Orm\Model
 		static::$_connection = \Config::get('ormauth.db_connection');
 		
 		// set the write connection this model should use
-		static::$_write_connection = \Config::get('ormauth.db_write_connection', static::$_connection);
+		static::$_write_connection = \Config::get('ormauth.db_write_connection') ?: static::$_connection;
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_role_permissions';

--- a/classes/model/auth/user.php
+++ b/classes/model/auth/user.php
@@ -217,7 +217,7 @@ class Auth_User extends \Orm\Model
 			static::$_connection = \Config::get('simpleauth.db_connection');
 		
 			// set the write connection this model should use
-			static::$_write_connection = \Config::get('simpleauth.db_write_connection', static::$_connection);
+			static::$_write_connection = \Config::get('simpleauth.db_write_connection') ?: static::$_connection;
 
 			// set the models table name
 			static::$_table_name = \Config::get('simpleauth.table_name', 'users');
@@ -236,7 +236,7 @@ class Auth_User extends \Orm\Model
 			static::$_connection = \Config::get('ormauth.db_connection');
 		
 			// set the write connection this model should use
-			static::$_write_connection = \Config::get('ormauth.db_write_connection', static::$_connection);
+			static::$_write_connection = \Config::get('ormauth.db_write_connection') ?: static::$_connection;
 
 			// set the models table name
 			static::$_table_name = \Config::get('ormauth.table_name', 'users');

--- a/classes/model/auth/userpermission.php
+++ b/classes/model/auth/userpermission.php
@@ -86,7 +86,7 @@ class Auth_Userpermission extends \Orm\Model
 		static::$_connection = \Config::get('ormauth.db_connection');
 		
 		// set the write connection this model should use
-		static::$_write_connection = \Config::get('ormauth.db_write_connection', static::$_connection);
+		static::$_write_connection = \Config::get('ormauth.db_write_connection') ?: static::$_connection;
 
 		// set the models table name
 		static::$_table_name = \Config::get('ormauth.table_name', 'users').'_user_permissions';


### PR DESCRIPTION
Amendment to previous pull-request. Using the default parameter in `config::get` won't work because the default config key still exists in ormauth config. However changed, if config value is null, default `$_write_connection` to `$_connection` using conditional statement.
