### PR TITLE
Register force_login so it can be logged out

### DIFF
--- a/classes/auth/login/simpleauth.php
+++ b/classes/auth/login/simpleauth.php
@@ -196,6 +196,10 @@ class Auth_Login_Simpleauth extends \Auth_Login_Driver
 
 		\Session::set('username', $this->user['username']);
 		\Session::set('login_hash', $this->create_login_hash());
+
+		// register so Auth::logout() can find us
+		Auth::_register_verified($this);
+
 		return true;
 	}
 


### PR DESCRIPTION
If you try to write tests to validate login/logout using force_login, you can't, as it won't log out. This adds the _register_verified hook to force_login to allow this.
