### PR TITLE
Register force_login so it can be logged out (Re #43)

### DIFF
--- a/classes/auth/login/simpleauth.php
+++ b/classes/auth/login/simpleauth.php
@@ -196,6 +196,10 @@ class Auth_Login_Simpleauth extends \Auth_Login_Driver
 
 		\Session::set('username', $this->user['username']);
 		\Session::set('login_hash', $this->create_login_hash());
+
+		// register so Auth::logout() can find us
+		Auth::_register_verified($this);
+
 		return true;
 	}
 


### PR DESCRIPTION
An addition to historical #43, but the same issue exists with force_login as with login() - if you don't check it, it's unable to be logged out, as it's never registered.
