### PR TITLE
Fixed a bug in \Auth::check() when using multiple login drivers

### DIFF
--- a/classes/auth.php
+++ b/classes/auth.php
@@ -189,30 +189,41 @@ class Auth
 	public static function check($specific = null)
 	{
 		$drivers = $specific === null ? static::$_instances : (array) $specific;
+		$verified = static::$_verified;
+		
+		if ($specific !== null)
+		{
+			$verified = array();
+			foreach ($drivers as $i)
+			{
+				$key = $i->get_id();
+				if (isset(static::$_verified[$key])) $verified[$key] = static::$_verified[$key];
+			}
+		}
 
 		foreach ($drivers as $i)
 		{
-			if ( ! static::$_verify_multiple && ! empty(static::$_verified))
+			if ( ! static::$_verify_multiple && ! empty($verified))
 			{
 				return true;
 			}
 
 			$i = $i instanceof Auth_Login_Driver ? $i : static::instance($i);
-			if ( ! array_key_exists($i->get_id(), static::$_verified))
+			if ( ! array_key_exists($i->get_id(), $verified))
 			{
 				$i->check();
 			}
 
 			if ($specific)
 			{
-				if (array_key_exists($i->get_id(), static::$_verified))
+				if (array_key_exists($i->get_id(), $verified))
 				{
 					return true;
 				}
 			}
 		}
 
-		return $specific === null && ! empty(static::$_verified);
+		return $specific === null && ! empty($verified);
 	}
 
 	/**


### PR DESCRIPTION
Fixed a bug in \Auth when using multiple login drivers with verify_multiple_logins set to false where having any one of them logged in would always cause \Auth::check() to return true even if the logged in one was excluded from the $specific parameter. 
