### PR TITLE
Renaming «Group» field into «usergroup» to avoid error from MySQL

### DIFF
--- a/classes/auth.php
+++ b/classes/auth.php
@@ -48,7 +48,7 @@ class Auth
 	 * @var  Array  subdriver registry, takes driver name and method for checking it
 	 */
 	protected static $_drivers = array(
-		'group'  => 'member',
+		'usergroup'  => 'member',
 		'acl'    => 'has_access',
 	);
 
@@ -291,7 +291,7 @@ class Auth
 		$driver_exists = ! is_string($type)
 						|| array_key_exists($type, static::$_drivers)
 						|| method_exists(get_called_class(), $check_method)
-						|| in_array($type, array('login', 'group', 'acl'));
+						|| in_array($type, array('login', 'usergroup', 'acl'));
 		$method_exists = ! is_string($type)
 						|| array_search($check_method, static::$_drivers)
 						|| method_exists(get_called_class(), $type);
@@ -319,7 +319,7 @@ class Auth
 	 */
 	public static function unregister_driver_type($type)
 	{
-		if (in_array($type, array('login', 'group', 'acl')))
+		if (in_array($type, array('login', 'usergroup', 'acl')))
 		{
 			\Error::notice('Cannot remove driver type, included drivers login, group and acl cannot be removed.');
 			return false;

--- a/classes/auth/login/ormauth.php
+++ b/classes/auth/login/ormauth.php
@@ -63,7 +63,7 @@ class Auth_Login_Ormauth extends \Auth_Login_Driver
 	 * @var  array  Ormauth class config
 	 */
 	protected $config = array(
-		'drivers' => array('group' => array('Ormgroup')),
+		'drivers' => array('usergroup' => array('Ormgroup')),
 		'additional_fields' => array(),
 	);
 
@@ -369,10 +369,10 @@ class Auth_Login_Ormauth extends \Auth_Login_Driver
 			unset($values['email']);
 		}
 		// deal with some simpleauth compatibility
-		if (array_key_exists('group', $values))
+		if (array_key_exists('usergroup', $values))
 		{
-			array_key_exists('group_id', $values) or $values['group_id'] = $values['group'];
-			unset($values['group']);
+			array_key_exists('group_id', $values) or $values['group_id'] = $values['usergroup'];
+			unset($values['usergroup']);
 		}
 		if (array_key_exists('group_id', $values))
 		{

--- a/classes/auth/login/simpleauth.php
+++ b/classes/auth/login/simpleauth.php
@@ -55,7 +55,7 @@ class Auth_Login_Simpleauth extends \Auth_Login_Driver
 	protected static $guest_login = array(
 		'id' => 0,
 		'username' => 'guest',
-		'group' => '0',
+		'usergroup' => '0',
 		'login_hash' => false,
 		'email' => false,
 	);
@@ -64,7 +64,7 @@ class Auth_Login_Simpleauth extends \Auth_Login_Driver
 	 * @var  array  SimpleAuth class config
 	 */
 	protected $config = array(
-		'drivers' => array('group' => array('Simplegroup')),
+		'drivers' => array('usergroup' => array('Simplegroup')),
 		'additional_fields' => array('profile_fields'),
 	);
 
@@ -261,7 +261,7 @@ class Auth_Login_Simpleauth extends \Auth_Login_Driver
 			'username'        => (string) $username,
 			'password'        => $this->hash_password((string) $password),
 			'email'           => $email,
-			'group'           => (int) $group,
+			'usergroup'           => (int) $group,
 			'profile_fields'  => serialize($profile_fields),
 			'last_login'      => 0,
 			'login_hash'      => '',
@@ -339,13 +339,13 @@ class Auth_Login_Simpleauth extends \Auth_Login_Driver
 			$update['email'] = $email;
 			unset($values['email']);
 		}
-		if (array_key_exists('group', $values))
+		if (array_key_exists('usergroup', $values))
 		{
-			if (is_numeric($values['group']))
+			if (is_numeric($values['usergroup']))
 			{
-				$update['group'] = (int) $values['group'];
+				$update['usergroup'] = (int) $values['usergroup'];
 			}
-			unset($values['group']);
+			unset($values['usergroup']);
 		}
 		if ( ! empty($values))
 		{
@@ -501,7 +501,7 @@ class Auth_Login_Simpleauth extends \Auth_Login_Driver
 			return false;
 		}
 
-		return array(array('Simplegroup', $this->user['group']));
+		return array(array('Simplegroup', $this->user['usergroup']));
 	}
 
 	/**

--- a/classes/model/auth/grouppermission.php
+++ b/classes/model/auth/grouppermission.php
@@ -62,7 +62,7 @@ class Auth_Grouppermission extends \Orm\Model
 	 * @var array	belongs_to relationships
 	 */
 	protected static $_belongs_to = array(
-		'group' => array(
+		'usergroup' => array(
 			'key_from' => 'group_id',
 			'model_to' => 'Model\\Auth_Group',
 			'key_to' => 'id',

--- a/classes/model/auth/user.php
+++ b/classes/model/auth/user.php
@@ -48,7 +48,7 @@ class Auth_User extends \Orm\Model
 			'null'        => false,
 			'validation'  => array('required', 'valid_email'),
 		),
-		'group'	          => array(
+		'usergroup'	          => array(
 			'label'       => 'auth_model_user.group_id',
 			'default'     => 0,
 			'null'        => false,
@@ -135,7 +135,7 @@ class Auth_User extends \Orm\Model
 	 * @var array	belongs_to relationships
 	 */
 	protected static $_belongs_to = array(
-		'group' => array(
+		'usergroup' => array(
 			'model_to' => 'Model\\Auth_Group',
 			'key_from' => 'group_id',
 			'key_to'   => 'id',
@@ -233,7 +233,7 @@ class Auth_User extends \Orm\Model
 		elseif (in_array('Ormauth', $drivers))
 		{
 			// remove properties not in use
-			unset(static::$_properties['group']);
+			unset(static::$_properties['usergroup']);
 			unset(static::$_properties['profile_fields']);
 
 			// ormauth config

--- a/migrations/001_auth_create_usertables.php
+++ b/migrations/001_auth_create_usertables.php
@@ -28,7 +28,7 @@ class Auth_Create_Usertables
 					'id' => array('type' => 'int', 'constraint' => 11, 'auto_increment' => true),
 					'username' => array('type' => 'varchar', 'constraint' => 50),
 					'password' => array('type' => 'varchar', 'constraint' => 255),
-					'group' => array('type' => 'int', 'constraint' => 11, 'default' => 1),
+					'usergroup' => array('type' => 'int', 'constraint' => 11, 'default' => 1),
 					'email' => array('type' => 'varchar', 'constraint' => 255),
 					'last_login' => array('type' => 'varchar', 'constraint' => 25),
 					'login_hash' => array('type' => 'varchar', 'constraint' => 255),
@@ -84,10 +84,10 @@ class Auth_Create_Usertables
 			}
 
 			// run a check on required fields, and deal with missing ones. we might be migrating from simpleauth
-			if (\DBUtil::field_exists($table, 'group'))
+			if (\DBUtil::field_exists($table, 'usergroup'))
 			{
 				\DBUtil::modify_fields($table, array(
-					'group' => array('name' => 'group_id', 'type' => 'int', 'constraint' => 11),
+					'usergroup' => array('name' => 'group_id', 'type' => 'int', 'constraint' => 11),
 				));
 			}
 			if ( ! \DBUtil::field_exists($table, 'group_id'))

--- a/tasks/simple2orm.php
+++ b/tasks/simple2orm.php
@@ -391,10 +391,10 @@ HELP;
 		}
 
 		// run a check on required fields, and deal with missing ones. we might be migrating from simpleauth
-		if (\DBUtil::field_exists(static::$data['ormauth_table'], 'group'))
+		if (\DBUtil::field_exists(static::$data['ormauth_table'], 'usergroup'))
 		{
 			\DBUtil::modify_fields(static::$data['ormauth_table'], array(
-				'group' => array('name' => 'group_id', 'type' => 'int', 'constraint' => 11),
+				'usergroup' => array('name' => 'group_id', 'type' => 'int', 'constraint' => 11),
 			));
 		}
 		if ( ! \DBUtil::field_exists(static::$data['ormauth_table'], 'group_id'))


### PR DESCRIPTION
By default, name «group» is reserved for MySQL.  So, creating «users» table fail (without any alert!).
This patch just rename field «group» into «usergroup».
In this way, there will be no more errors for creating/using «users» table.

Signed-off-by: chindit <littletiger58_/a/_/t/_gmail.com>
