### PR TITLE
Fixed a bug in \Auth::check() when using $specific is string

### DIFF
--- a/classes/auth.php
+++ b/classes/auth.php
@@ -193,6 +193,7 @@ class Auth
 			$verified = array();
 			foreach ($drivers as $i)
 			{
+				$i = $i instanceof Auth_Login_Driver ? $i : static::instance($i);
 				$key = $i->get_id();
 				if (isset(static::$_verified[$key])) $verified[$key] = static::$_verified[$key];
 			}


### PR DESCRIPTION
Fixed a cause error in \Auth::check() when $specific parameter is string.
