### PR TITLE
Fix model user properties "group" and "group_id" validaiton

### DIFF
--- a/classes/model/auth/user.php
+++ b/classes/model/auth/user.php
@@ -53,14 +53,14 @@ class Auth_User extends \Orm\Model
 			'default'     => 0,
 			'null'        => false,
 			'form'        => array('type' => 'select'),
-			'validation'  => array('required', 'match_pattern' => array('^[1-9]\d*$')),
+			'validation'  => array('required', 'match_pattern' => array('/^[1-9]\d*$/')),
 		),
 		'group_id'        => array(
 			'label'       => 'auth_model_user.group_id',
 			'default'     => null,
 			'null'        => true,
 			'form'        => array('type' => 'select'),
-			'validation'  => array('match_pattern' => array('^[1-9]\d*$')),
+			'validation'  => array('match_pattern' => array('/^[1-9]\d*$/')),
 		),
 		'password'        => array(
 			'label'       => 'auth_model_user.password',


### PR DESCRIPTION
"Group" and "group_id" validation's match_pattern strings needed
to be delimited to work correctly and not throw an error when
running validation on a form based on this model.