### PR TITLE
#change current() to next() in simpleauth to get the first result

### DIFF
--- a/classes/auth/login/simpleauth.php
+++ b/classes/auth/login/simpleauth.php
@@ -85,7 +85,7 @@ class Auth_Login_Simpleauth extends \Auth_Login_Driver
 				$this->user = \DB::select_array(\Config::get('simpleauth.table_columns', array('*')))
 					->where('username', '=', $username)
 					->from(\Config::get('simpleauth.table_name'))
-					->execute(\Config::get('simpleauth.db_connection'))->current();
+					->execute(\Config::get('simpleauth.db_connection'))->next();
 			}
 
 			// return true when login was verified, and either the hash matches or multiple logins are allowed
@@ -132,7 +132,7 @@ class Auth_Login_Simpleauth extends \Auth_Login_Driver
 			->where_close()
 			->where('password', '=', $password)
 			->from(\Config::get('simpleauth.table_name'))
-			->execute(\Config::get('simpleauth.db_connection'))->current();
+			->execute(\Config::get('simpleauth.db_connection'))->next();
 
 		return $user ?: false;
 	}
@@ -182,7 +182,7 @@ class Auth_Login_Simpleauth extends \Auth_Login_Driver
 			->where_close()
 			->from(\Config::get('simpleauth.table_name'))
 			->execute(\Config::get('simpleauth.db_connection'))
-			->current();
+			->next();
 
 		if ($this->user == false)
 		{
@@ -245,7 +245,7 @@ class Auth_Login_Simpleauth extends \Auth_Login_Driver
 
 		if ($same_users->count() > 0)
 		{
-			if (in_array(strtolower($email), array_map('strtolower', $same_users->current())))
+			if (in_array(strtolower($email), array_map('strtolower', $same_users->next())))
 			{
 				throw new \SimpleUserUpdateException('Email address already exists', 2);
 			}
@@ -375,7 +375,7 @@ class Auth_Login_Simpleauth extends \Auth_Login_Driver
 			$this->user = \DB::select_array(\Config::get('simpleauth.table_columns', array('*')))
 				->where('username', '=', $username)
 				->from(\Config::get('simpleauth.table_name'))
-				->execute(\Config::get('simpleauth.db_connection'))->current();
+				->execute(\Config::get('simpleauth.db_connection'))->next();
 		}
 
 		return $affected_rows > 0;


### PR DESCRIPTION
DB::select_array->execute()->current()  is always null even though there are results in the array. Using next() will get the first one.

There may be a better way to resolve it but that worked for me

I was upgrading my fuelphp 1.0 -> 1.9, php 5.3 -> 7.* 